### PR TITLE
adding log wrapper

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,1 +1,2 @@
 default['boxstarter']['tmp_dir'] = "#{ENV['TEMP']}/boxstarter"
+default['boxstarter']['loglevel'] = 'info'

--- a/libraries/check_process_tree.rb
+++ b/libraries/check_process_tree.rb
@@ -6,17 +6,17 @@ module BoxstarterLibrary
     end
 
     def check_process_tree_internal(wmi, parent, attr, match)
-      Chef::Log.debug "***Looking for parents running as #{match} at pid #{parent}***"
+      boxlog "***Looking for parents running as #{match} at pid #{parent}***"
 
       if parent.nil?
-        Chef::Log.debug "***No more parents. Finished looking for #{match} parents***"
+        boxlog "***No more parents. Finished looking for #{match} parents***"
         return nil 
       end
 
       parent_proc = wmi.ExecQuery("Select * from Win32_Process where ProcessID=#{parent}")
       
       if parent_proc.each.count == 0
-        Chef::Log.debug "***No process for pid #{parent}. Finished looking for #{match} parents***"
+        boxlog "***No process for pid #{parent}. Finished looking for #{match} parents***"
         return nil
       end
 
@@ -24,17 +24,22 @@ module BoxstarterLibrary
 
       result = proc.send(attr)
       if !result.nil? && result.downcase.include?(match)
-        Chef::Log.debug "***Found #{match} parent pid #{parent}...returning true***"
+        boxlog "***Found #{match} parent pid #{parent}...returning true***"
         return proc 
       end
 
       if proc.Name == 'services.exe'
-        Chef::Log.debug "***Proc was running #{proc.Name}...quitting since this is the effective trunk***"
+        boxlog "***Proc was running #{proc.Name}...quitting since this is the effective trunk***"
         return nil
       end
 
-      Chef::Log.debug "***Proc was running #{proc.Name}...trying its parent***"
+      boxlog "***Proc was running #{proc.Name}...trying its parent***"
       return check_process_tree_internal(wmi, proc.ParentProcessID, attr, match)
     end
+
+    def boxlog(msg = '')
+      Chef::Log.send(node['boxstarter']['loglevel'])
+    end
+
   end
 end

--- a/libraries/command.rb
+++ b/libraries/command.rb
@@ -46,7 +46,7 @@ module BoxstarterLibrary
         $host.SetShouldExit($result.errors.count)
       }
       EOS
-      Chef::Log.debug "wrapping boxstarter invocation script: #{command}"
+      boxlog "wrapping boxstarter invocation script: #{command}"
       command = command.chars.to_a.join("\x00").chomp
       command << "\x00" unless command[-1].eql? "\x00"
       if(defined?(command.encode))

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -48,7 +48,7 @@ action :run do
     ruby_block "Run Boxstarter Package" do
       block do
         cmd = Mixlib::ShellOut.new(batch_path)
-        Chef::Log.debug(cmd)
+        boxlog(cmd)
         cmd.live_stream = STDOUT
         cmd.timeout = 7200
         cmd.run_command


### PR DESCRIPTION
I heard complaints that boxstarter resource is too noisy. I added an attribute to control log spew and set default to 'info'.

I wasn't able to start rspec from this repo, so the commit is completely and totally untested.
