### PR TITLE
remove send call, change appdata to programdata

### DIFF
--- a/libraries/command.rb
+++ b/libraries/command.rb
@@ -28,11 +28,11 @@ module BoxstarterLibrary
       #we will need to create a scheduled task for operations that do
       #not work remotely
       if($isRemote -and $creds){
-        Import-Module "$env:appdata/boxstarter/Boxstarter.Common/Boxstarter.Common.psd1"
+        Import-Module "$env:programdata/boxstarter/Boxstarter.Common/Boxstarter.Common.psd1"
         Create-BoxstarterTask $creds
       }
 
-      Import-Module "$env:appdata/boxstarter/Boxstarter.Chocolatey/Boxstarter.Chocolatey.psd1"
+      Import-Module "$env:programdata/boxstarter/Boxstarter.Chocolatey/Boxstarter.Chocolatey.psd1"
       $result = Install-BoxstarterPackage @params
 
       if($result.errors.count -gt 0) {

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,4 +1,4 @@
-Chef::Provider::Boxstarter.send(:include, BoxstarterLibrary::Helper)
+# Chef::Provider::Boxstarter.send(:include, BoxstarterLibrary::Helper)
 
 version = nil
 if node['boxstarter']['version']


### PR DESCRIPTION
was never able to make it compile with the send call, but it ran fine when I removed it. also, nothing was ever being written to appdata/boxstarter in any of my runs, only programdata/boxstarter. With these 2 changes, all aspects of this cookbook work great for me. 